### PR TITLE
Document Ollama tool-calling caveats for local stage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ Microsoft Agent Framework typing issue tracked upstream:
 
 * https://github.com/microsoft/agent-framework/issues/6938 - `Agent(client=FoundryChatClient(...))` reports a static type mismatch in `ty` despite working at runtime.
 
-Ollama issues that cause some models to behave poorly with the Ollama Responses API, as described in [https://github.com/Azure-Samples/foundry-hosted-agentframework-demos/issues/3](issue #3):
+Ollama issues that cause some models to behave poorly with the Ollama Responses API, as described in [issue #3](https://github.com/Azure-Samples/foundry-hosted-agentframework-demos/issues/3):
 
 * https://github.com/ollama/ollama/issues/15573 - Gemma4 tool-calling can enter an infinite loop in some setups.
 * https://github.com/ollama/ollama/issues/15719 - Gemma4 infinite tool-call loop reported through LiteLLM/OpenAI-compatible proxy path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ Microsoft Agent Framework typing issue tracked upstream:
 
 * https://github.com/microsoft/agent-framework/issues/6938 - `Agent(client=FoundryChatClient(...))` reports a static type mismatch in `ty` despite working at runtime.
 
-Ollama OpenAI-compat/tool-calling issues tracked upstream:
+Ollama issues that cause some models to behave poorly with the Ollama Responses API, as described in [https://github.com/Azure-Samples/foundry-hosted-agentframework-demos/issues/3](issue #3):
 
 * https://github.com/ollama/ollama/issues/15573 - Gemma4 tool-calling can enter an infinite loop in some setups.
 * https://github.com/ollama/ollama/issues/15719 - Gemma4 infinite tool-call loop reported through LiteLLM/OpenAI-compatible proxy path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,14 @@ Microsoft Agent Framework typing issue tracked upstream:
 
 * https://github.com/microsoft/agent-framework/issues/6938 - `Agent(client=FoundryChatClient(...))` reports a static type mismatch in `ty` despite working at runtime.
 
+Ollama OpenAI-compat/tool-calling issues tracked upstream:
+
+* https://github.com/ollama/ollama/issues/15573 - Gemma4 tool-calling can enter an infinite loop in some setups.
+* https://github.com/ollama/ollama/issues/15719 - Gemma4 infinite tool-call loop reported through LiteLLM/OpenAI-compatible proxy path.
+* https://github.com/ollama/ollama/issues/15921 - Responses API parity gap: missing `namespace` support in tool calls.
+* https://github.com/ollama/ollama/issues/10976 - OpenAI-compatible tool-calling compatibility gaps across models/providers.
+* https://github.com/ollama/ollama/issues/14601 - Qwen tool-calling reliability issues in OpenAI-compatible usage.
+
 ## Relevant documentation
 
 MAF Observability

--- a/agents/stage0_local_model.py
+++ b/agents/stage0_local_model.py
@@ -44,7 +44,7 @@ def get_enrollment_deadline_info() -> dict:
 
 # Ollama exposes an OpenAI-compatible endpoint; no API key needed.
 # qwen3.5:4b works well here, but some models may behave better with
-# OpenAIChatCompletionClient instead of OpenAIChatClient
+# OpenAIChatCompletionClient (uses /v1/chat/completions) instead of OpenAIChatClient (uses /v1/responses).
 client = OpenAIChatClient(
     base_url="http://localhost:11434/v1/",
     api_key="no-key-needed",  # any non-empty string

--- a/agents/stage0_local_model.py
+++ b/agents/stage0_local_model.py
@@ -6,8 +6,11 @@ No cloud, no account required. Demonstrates the core agent loop:
 
 Prerequisites:
     1. Install Ollama: https://ollama.com/download
-    2. Pull a small model that supports tool calling, e.g.:
-         ollama pull llama3.2
+        2. Pull a small model that supports tool calling.
+             This script defaults to `qwen3.5:4b`, so pull that model or update
+             the `model=` value below to one you already have, e.g.:
+                 ollama pull qwen3.5:4b
+                 ollama pull llama3.2
     3. Make sure Ollama is running (it serves an OpenAI-compatible API
        at http://localhost:11434/v1 by default).
 

--- a/agents/stage0_local_model.py
+++ b/agents/stage0_local_model.py
@@ -6,11 +6,11 @@ No cloud, no account required. Demonstrates the core agent loop:
 
 Prerequisites:
     1. Install Ollama: https://ollama.com/download
-        2. Pull a small model that supports tool calling.
-             This script defaults to `qwen3.5:4b`, so pull that model or update
-             the `model=` value below to one you already have, e.g.:
-                 ollama pull qwen3.5:4b
-                 ollama pull llama3.2
+    2. Pull a small model that supports tool calling.
+        This script defaults to `qwen3.5:4b`, so pull that model or update
+        the `model=` value below to one you already have, e.g.:
+            ollama pull qwen3.5:4b
+            ollama pull llama3.2
     3. Make sure Ollama is running (it serves an OpenAI-compatible API
        at http://localhost:11434/v1 by default).
 
@@ -44,7 +44,7 @@ def get_enrollment_deadline_info() -> dict:
 
 # Ollama exposes an OpenAI-compatible endpoint; no API key needed.
 # qwen3.5:4b works well here, but some models may behave better with
-# OpenAIChatCompletionClient for tool-calling reliability.
+# OpenAIChatCompletionClient instead of OpenAIChatClient
 client = OpenAIChatClient(
     base_url="http://localhost:11434/v1/",
     api_key="no-key-needed",  # any non-empty string

--- a/agents/stage0_local_model.py
+++ b/agents/stage0_local_model.py
@@ -40,6 +40,8 @@ def get_enrollment_deadline_info() -> dict:
 
 
 # Ollama exposes an OpenAI-compatible endpoint; no API key needed.
+# qwen3.5:4b works well here, but some models may behave better with
+# OpenAIChatCompletionClient for tool-calling reliability.
 client = OpenAIChatClient(
     base_url="http://localhost:11434/v1/",
     api_key="no-key-needed",  # any non-empty string


### PR DESCRIPTION
## Purpose
* Document relevant upstream Ollama issues in known issues and clarify Stage 0 client behavior by model.
* Add context that `qwen3.5:4b` works well with `OpenAIChatClient`, while some models may be more reliable with `OpenAIChatCompletionClient` for tool-calling.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/Azure-Samples/foundry-hosted-agentframework-demos
cd foundry-hosted-agentframework-demos
git checkout docs/ollama-known-issues-and-stage0-note
```

* Test the code
```
Review AGENTS.md "Known issues" section for the new Ollama issue links.
Review agents/stage0_local_model.py for the note above OpenAIChatClient.
```

## What to Check
Verify that the following are valid
* Known issues section includes high-signal upstream Ollama issues related to tool-calling loops/parity.
* Stage 0 note communicates model-dependent client reliability without changing behavior.

## Other Information
* Related issue: #3
